### PR TITLE
Always downcase UUID strings

### DIFF
--- a/lib/mysql-binuuid/type.rb
+++ b/lib/mysql-binuuid/type.rb
@@ -12,13 +12,17 @@ module MySQLBinUUID
       if value.is_a?(MySQLBinUUID::Type::Data)
         # It could be a Data object, in which case we should add dashes to the
         # string value from there.
-        add_dashes(value.to_s)
-      elsif value.is_a?(String) && value.encoding == Encoding::ASCII_8BIT && strip_dashes(value).length != 32
-        # We cannot unpack something that looks like a UUID, with or without
-        # dashes. Not entirely sure why ActiveRecord does a weird combination of
-        # cast and serialize before anything needs to be saved..
-        undashed_uuid = value.unpack1('H*')
-        add_dashes(undashed_uuid.to_s)
+        add_dashes(value.to_s.downcase)
+      elsif value.is_a?(String)
+        if value.encoding == Encoding::ASCII_8BIT && strip_dashes(value).length != 32
+          # We cannot unpack something that looks like a UUID, with or without
+          # dashes. Not entirely sure why ActiveRecord does a weird combination of
+          # cast and serialize before anything needs to be saved..
+          undashed_uuid = value.unpack1('H*')
+          add_dashes(undashed_uuid.to_s.downcase)
+        else
+          value.downcase
+        end
       else
         super
       end

--- a/test/integration/mysql_integration_test.rb
+++ b/test/integration/mysql_integration_test.rb
@@ -170,7 +170,7 @@ class MySQLIntegrationTest < ActiveSupport::TestCase
       UuidChild.delete_all
     end
 
-    test "beep boop" do
+    test "does not dirty data on association reloads" do
       @parent.uuid_children.build
       @parent.save!
       @parent.uuid_children.reload

--- a/test/integration/mysql_integration_test.rb
+++ b/test/integration/mysql_integration_test.rb
@@ -4,8 +4,31 @@ class MyUuidModel < ActiveRecord::Base
   attribute :the_uuid, MySQLBinUUID::Type.new
 end
 
+class UuidPkeyModel < ActiveRecord::Base
+  self.abstract_class = true
+
+  attribute :id, MySQLBinUUID::Type.new
+
+  after_initialize :set_id
+
+  private
+
+  def set_id
+    self.id ||= SecureRandom.uuid
+  end
+end
+
 class MyUuidModelWithValidations < MyUuidModel
   validates :the_uuid, uniqueness: true
+end
+
+class UuidParent < UuidPkeyModel
+  has_many :uuid_children
+end
+
+class UuidChild < UuidPkeyModel
+  belongs_to :uuid_parent
+  attribute :uuid_parent_id, MySQLBinUUID::Type.new
 end
 
 class MySQLIntegrationTest < ActiveSupport::TestCase
@@ -35,6 +58,9 @@ class MySQLIntegrationTest < ActiveSupport::TestCase
     ActiveRecord::Base.establish_connection(db_config)
     connection.create_table("my_uuid_models")
     connection.add_column("my_uuid_models", "the_uuid", :binary, limit: 16)
+    connection.create_table('uuid_parents', id: 'binary(16)')
+    connection.create_table('uuid_children', id: 'binary(16)')
+    connection.add_columns('uuid_children', 'uuid_parent_id', type: 'binary(16)')
 
     # Uncomment this line to get logging on stdout
     # ActiveRecord::Base.logger = Logger.new(STDOUT)
@@ -121,6 +147,35 @@ class MySQLIntegrationTest < ActiveSupport::TestCase
       assert_raises MySQLBinUUID::InvalidUUID do
         MyUuidModel.create!(the_uuid: "40' + x'40")
       end
+    end
+
+    test "always downcases the user-supplied value" do
+      @my_model.the_uuid = @sample_uuid.upcase
+      assert_equal @sample_uuid, @my_model.the_uuid
+    end
+
+    test "treats case-only changes as non-dirtying" do
+      @my_model.the_uuid = @sample_uuid.upcase
+      assert_equal false, @my_model.will_save_change_to_the_uuid?
+    end
+  end
+
+  class ComplexRelationTest < MySQLIntegrationTest
+    setup do
+      @parent = UuidParent.new(id: SecureRandom.uuid.upcase)
+    end
+
+    teardown do
+      UuidParent.delete_all
+      UuidChild.delete_all
+    end
+
+    test "beep boop" do
+      @parent.uuid_children.build
+      @parent.save!
+      @parent.uuid_children.reload
+
+      refute @parent.uuid_children.first.uuid_parent_id_changed?
     end
   end
 end


### PR DESCRIPTION
Hexadecimal representations of binary data are inherently case-insensitive; in base 16, "A" is the same as "a". UUID attributes handled by this gem are stored in the database as binary, so are as such case-insensitive.

We should accordingly ensure UUIDs that have different string cases (e.g. `9c71296e-6d84-470c-878e-3ca10ef2c6aa` vs `9C71296E-6D84-470C-878E-3CA10EF2C6AA`) are actually treated as equivalent. This is particularly important with ActiveRecord associations and dirty logic, where reloading an association will change the record's view of the in-database UUID (always lowercase), which ultimately marks the record as dirty since the in-memory UUID is uppercase.